### PR TITLE
provide support for sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ TestResult.xml
 [Dd]ebugPS/
 [Rr]eleasePS/
 dlldata.c
+realworld.db
 
 # DNX
 project.lock.json

--- a/GenVue.csproj
+++ b/GenVue.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.3" />
   </ItemGroup>
   <ItemGroup>
     <!-- Files not to show in IDE -->

--- a/Startup.cs
+++ b/Startup.cs
@@ -63,16 +63,22 @@ namespace GenVue
             services.AddDbContext<DefaultDbContext>(options =>
             {
                 // database driver selection
-                if (Configuration["Data:Provider"] == "postgress" )
+                switch (Configuration["Data:Provider"])
                 {
-                    // Configure the context to use Postgress database.
-                    // Tested on Postgress 10
-                    options.UseNpgsql(Configuration["Data:DefaultConnection:ConnectionString"]);
-                }
-                else
-                {
-                    // Configure the context to use Microsoft SQL Server.
-                    options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]);
+                    case "postgress":
+                         // Configure the context to use Postgress database.
+                        // Tested on Postgress 10
+                        options.UseNpgsql(Configuration["Data:DefaultConnection:ConnectionString"]);
+                        break;
+                    case "sqlite":
+                        options.UseSqlite("Filename="+Configuration["Data:DefaultConnection:databaseName"]);
+                        break;
+                    case "sqlserver":
+                        // Configure the context to use Microsoft SQL Server.
+                        options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]);
+                        break;
+                    default:
+                        break;
                 }
 
                 // Register the entity sets needed by OpenIddict.

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,10 +1,14 @@
 {
     "Data": {
         // Provider suppoted databases: "sqlserver", "postgress"
-        "Provider": "sqlserver",
+        "Provider": "sqlite",
         "DefaultConnection": {
-            "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=genvue;Trusted_Connection=True;MultipleActiveResultSets=true"
+            "databaseName": "realworld.db"
         }
+        // "Provider": "sqlserver",
+        // "DefaultConnection": {
+        //     "ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=genvue;Trusted_Connection=True;MultipleActiveResultSets=true"
+        // }
         // simply uncomment below and comment section up to switch between databases
         //"Provider": "postgress",
         //"DefaultConnection": {


### PR DESCRIPTION
some systems don't support sqlserver in memory. sqlite may be better. I also changed the startup.cs to be a switch statement instead of if for selecting db by provider.